### PR TITLE
test: arm64 detection

### DIFF
--- a/net-proxy/sing-box/sing-box-1.13.14.ebuild
+++ b/net-proxy/sing-box/sing-box-1.13.14.ebuild
@@ -96,3 +96,5 @@ src_install() {
 	dofishcomp completions/sing-box.fish
 	dozshcomp completions/_sing-box
 }
+
+# ci: trigger arm64 detection test

--- a/x11-themes/kvantum-black/kvantum-black-0.2.0.ebuild
+++ b/x11-themes/kvantum-black/kvantum-black-0.2.0.ebuild
@@ -20,3 +20,5 @@ src_install() {
 
 	dodoc README.md
 }
+
+# ci: trigger amd64-only detection test


### PR DESCRIPTION
throwaway: verify emerge scan targets + arm64 job