### PR TITLE
test: new-vs-existing findings

### DIFF
--- a/dev-util/mamba/mamba-2.5.0.ebuild
+++ b/dev-util/mamba/mamba-2.5.0.ebuild
@@ -18,6 +18,8 @@ LICENSE="BSD"
 SLOT="0/3"
 KEYWORDS="~amd64"
 IUSE="python mamba"
+
+
 # Test requires network access
 RESTRICT="test"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"


### PR DESCRIPTION
Throwaway. dev-util/mamba already has 3 findings; this adds one ExcessiveLineLength. Expect: 1 new, 3 pre-existing.